### PR TITLE
Add option to disable generation of sourcemaps

### DIFF
--- a/lib/stream-files.js
+++ b/lib/stream-files.js
@@ -25,12 +25,18 @@ module.exports.scripts = function (opts) {
   var self = this;
   return gulp.src(opts.src, {base: opts.base})
     .pipe(using.bundle(opts.bundleName, BundleKeys.SCRIPTS, opts.env, opts.isBundleAll))
-    .pipe(sourcemaps.init({loadMaps: true}))
+    .pipe(gif(function(file) {
+        return opts.bundleOptions.maps;
+      }, sourcemaps.init({loadMaps: true})
+    ))
     .pipe(opts.bundleOptions.transforms[BundleKeys.SCRIPTS]())
     .on('error', function (e) {
       self.handleTransformError(opts.bundleName, BundleKeys.SCRIPTS, e);
     })
-    .pipe(through.obj(verifySourcemaps))
+    .pipe(gif(function(file) {
+        return opts.bundleOptions.maps;
+      }, through.obj(verifySourcemaps)
+    ))
     .pipe(gif(function (file) {
         return isMinEnabled.js(file, opts);
       },
@@ -52,7 +58,10 @@ module.exports.scripts = function (opts) {
         return file.isStream();
       }, streamify(rev()), rev())
     ))
-    .pipe(sourcemaps.write('maps'))
+    .pipe(gif(function(file) {
+        return opts.bundleOptions.maps;
+      }, sourcemaps.write('maps')
+    ))
     .pipe(addBundleResultsToFile(opts.bundleName, BundleKeys.SCRIPTS, opts.bundleOptions.result, opts.env, opts.isBundleAll));
 };
 
@@ -60,17 +69,27 @@ module.exports.styles = function (opts) {
   var self = this;
   return gulp.src(opts.src, {base: opts.base})
     .pipe(using.bundle(opts.bundleName, BundleKeys.STYLES, opts.env, opts.isBundleAll))
-    .pipe(sourcemaps.init({loadMaps: true}))
+    .pipe(
+      gif(function(file) {
+        return opts.bundleOptions.maps;
+      }, sourcemaps.init({loadMaps: true})
+    ))
     .pipe(opts.bundleOptions.transforms[BundleKeys.STYLES]())
     .on('error', function (e) {
       self.handleTransformError(opts.bundleName, BundleKeys.STYLES, e);
     })
-    .pipe(through.obj(verifySourcemaps))
+    .pipe(gif(function(file) {
+        return opts.bundleOptions.maps;
+      }, through.obj(verifySourcemaps)
+    ))
     .pipe(gif(function (file) {
       return isMinEnabled.css(file, opts);
     }, minifyCSS()))
     .pipe(concat(opts.bundleName + ((opts.isBundleAll && opts.env) ? '.' + opts.env : '') + '.css'))
     .pipe(gif(isOptionEnabled(opts.bundleOptions.rev, opts.env), rev()))
-    .pipe(sourcemaps.write('maps'))
+    .pipe(gif(function(file) {
+        return opts.bundleOptions.maps;
+      }, sourcemaps.write('maps')
+    ))
     .pipe(addBundleResultsToFile(opts.bundleName, BundleKeys.STYLES, opts.bundleOptions.result, opts.env, opts.isBundleAll));
 };

--- a/lib/stream-files.js
+++ b/lib/stream-files.js
@@ -26,7 +26,7 @@ module.exports.scripts = function (opts) {
   return gulp.src(opts.src, {base: opts.base})
     .pipe(using.bundle(opts.bundleName, BundleKeys.SCRIPTS, opts.env, opts.isBundleAll))
     .pipe(gif(function(file) {
-        return opts.bundleOptions.maps;
+        return opts.bundleOptions.maps === undefined || opts.bundleOptions.maps === true;
       }, sourcemaps.init({loadMaps: true})
     ))
     .pipe(opts.bundleOptions.transforms[BundleKeys.SCRIPTS]())
@@ -34,7 +34,7 @@ module.exports.scripts = function (opts) {
       self.handleTransformError(opts.bundleName, BundleKeys.SCRIPTS, e);
     })
     .pipe(gif(function(file) {
-        return opts.bundleOptions.maps;
+        return opts.bundleOptions.maps === undefined || opts.bundleOptions.maps === true;
       }, through.obj(verifySourcemaps)
     ))
     .pipe(gif(function (file) {
@@ -59,7 +59,7 @@ module.exports.scripts = function (opts) {
       }, streamify(rev()), rev())
     ))
     .pipe(gif(function(file) {
-        return opts.bundleOptions.maps;
+        return opts.bundleOptions.maps === undefined || opts.bundleOptions.maps === true;
       }, sourcemaps.write('maps')
     ))
     .pipe(addBundleResultsToFile(opts.bundleName, BundleKeys.SCRIPTS, opts.bundleOptions.result, opts.env, opts.isBundleAll));
@@ -71,7 +71,7 @@ module.exports.styles = function (opts) {
     .pipe(using.bundle(opts.bundleName, BundleKeys.STYLES, opts.env, opts.isBundleAll))
     .pipe(
       gif(function(file) {
-        return opts.bundleOptions.maps;
+        return opts.bundleOptions.maps === undefined || opts.bundleOptions.maps === true;
       }, sourcemaps.init({loadMaps: true})
     ))
     .pipe(opts.bundleOptions.transforms[BundleKeys.STYLES]())
@@ -79,7 +79,7 @@ module.exports.styles = function (opts) {
       self.handleTransformError(opts.bundleName, BundleKeys.STYLES, e);
     })
     .pipe(gif(function(file) {
-        return opts.bundleOptions.maps;
+        return opts.bundleOptions.maps === undefined || opts.bundleOptions.maps === true;
       }, through.obj(verifySourcemaps)
     ))
     .pipe(gif(function (file) {
@@ -88,7 +88,7 @@ module.exports.styles = function (opts) {
     .pipe(concat(opts.bundleName + ((opts.isBundleAll && opts.env) ? '.' + opts.env : '') + '.css'))
     .pipe(gif(isOptionEnabled(opts.bundleOptions.rev, opts.env), rev()))
     .pipe(gif(function(file) {
-        return opts.bundleOptions.maps;
+        return opts.bundleOptions.maps === undefined || opts.bundleOptions.maps === true;
       }, sourcemaps.write('maps')
     ))
     .pipe(addBundleResultsToFile(opts.bundleName, BundleKeys.STYLES, opts.bundleOptions.result, opts.env, opts.isBundleAll));


### PR DESCRIPTION
I added the option to disable sourcemaps.

Example bundle.config.js:

```
module.exports = {
  bundle: {
    main: {
      styles: ['./public/less/styles.less','./public/less/bootstrap.less','./public/less/font-awesome/font-awesome.less'],
      options: {
        transforms: {
          styles: less // pipe(s) of style transforms
        },
        maps: false
      }
    }
  }
};
```