### PR TITLE
fixed separator on windows for result.json

### DIFF
--- a/lib/results/type/index.js
+++ b/lib/results/type/index.js
@@ -8,7 +8,7 @@ module.exports = function(file, pathPrefix) {
   var bundleType = file.bundle.type;
   var resulter = loadResulter(file.bundle.result.type, bundleType);
   var bundlePath = (pathPrefix) ? pathPrefix + file.relative : file.relative;
-  return resulter(bundlePath);
+  return resulter(bundlePath.replace(/\\/g, '/'));
 };
 
 /**

--- a/test/unit/results/results-test.js
+++ b/test/unit/results/results-test.js
@@ -127,6 +127,43 @@ describe('results', function () {
       stream.write(cssFile);
       stream.end();
     });
+    
+    it('should write results path in a posix way', function (done) {
+
+      var fsStub = {
+        writeFile: function (writePath, data, cb) {
+          (writePath).should.eql(path.join(resultPath, 'bundle.result.json'));
+          (JSON.parse(data)).should.eql({
+            "main": {
+              "scripts": "<script src='/public/main.js' type='text/javascript'></script>",
+              "styles": "<link href='/public/main.css' media='all' rel='stylesheet' type='text/css'/>"
+            }
+          });
+          cb();
+        }
+      };
+
+      results = proxyquire(libPath + '/results', { 'mkdirp': mkdirpStub, 'graceful-fs': fsStub, 'gulp-util': gutilStub }).all;
+
+      var stream = results({
+        dest: resultPath,
+        pathPrefix: '\\public\\'
+      });
+
+      stream.on('data', function (file) {
+        // make sure it came out the same way it went in
+        file.isBuffer().should.be.ok;
+        file.bundle.should.be.ok;
+      });
+
+      stream.on('end', function () {
+        done();
+      });
+
+      stream.write(jsFile);
+      stream.write(cssFile);
+      stream.end();
+    });
 
   });
 


### PR DESCRIPTION
To have each bundle into separate subfolders, it's currently possible to have such a thing having the bundle named like 'js/vendor'. 
On windows there is an error where \ is used in the result.json file. E.g. 
config.js:
```
	bundle : {
		'js/vendor' : {
			scripts : [
...
```
produces
```
  "js/vendor": {
    "scripts": "js\vendor-9de064e6.js"
  }
```

this PR covers this point. The unit test doesn't cover exactly the above case but uses the pathPrefix option for windows like separator.