### PR TITLE
Use gulp-concat-css to maintain css import links

### DIFF
--- a/lib/stream-files.js
+++ b/lib/stream-files.js
@@ -2,6 +2,7 @@ var gulp = require('gulp'),
   through = require('through2'),
   gif = require('gulp-if'),
   concat = require('gulp-concat'),
+  concatCss = require('gulp-concat-css'),
   uglify = require('gulp-uglify'),
   rev = require('gulp-rev'),
   streamify = require('gulp-streamify'),
@@ -131,7 +132,7 @@ module.exports.styles = function (opts) {
         return opts.bundleOptions.order && opts.bundleOptions.order.styles;
       }, order(opts.bundleOptions.order.styles)
     ))
-    .pipe(concat(opts.bundleName + ((opts.isBundleAll && opts.env) ? '.' + opts.env : '') + '.css'))
+    .pipe(concatCss(opts.bundleName + ((opts.isBundleAll && opts.env) ? '.' + opts.env : '') + '.css'))
     .pipe(gif(isOptionEnabled(opts.bundleOptions.rev, opts.env), rev()))
     .pipe(gif(function (file) {
         return sourcemaps.isEnabled(opts);

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "gulp-clean-css": "2.0.7",
     "gulp-coffee": "2.3.2",
     "gulp-concat": "2.5.2",
+    "gulp-concat-css": "2.3.0",
     "gulp-if": "2.0.1",
     "gulp-less": "3.1.0",
     "gulp-order": "1.1.1",


### PR DESCRIPTION
Before `gulp-concat` was being used for merging files.

This is fine for JS and however issues can be encountered with when bundling CSS that contain relative urls, especially if CSS is pulled from different directory levels.

This issue has been observed in [UserFrosting 4](https://github.com/userfrosting/UserFrosting), specifically the breaking of font imports for the AdminLTE CSS.

The fix is simple, use `gulp-concat-css` instead of `gulp-concat` for `styles` bundles.

Tests have been performed to ensure compatibility, however it was quickly found that tests for the master branch are failing. There does not appear to be any changes to the tests that fail are implementing the changes, which is promising.